### PR TITLE
WaitForSelector no passo de criação inválida na Feature de Agendamentos

### DIFF
--- a/tests/features/step_definitions/agendamento.js
+++ b/tests/features/step_definitions/agendamento.js
@@ -208,6 +208,7 @@ Then('Eu posso ver uma mensagem de agendamento inválido', async function () {
     let validation = false
     await page.click('#confirm_creation')
 
+    await page.waitForSelector('h2[id^=swal]')
     const confirmCreation = await page.$('h2[id^=swal]')
     const texto = await (await confirmCreation.getProperty('innerText')).jsonValue()
     if (texto === 'O dentista não está disponível nesse horário.' || texto === 'Por favor insira todas as informações para o agendamento.') {


### PR DESCRIPTION
Um "waitForSelector" estava faltando no passo de "Eu posso ver uma mensagem de agendamento inválido" que é usado por dois cenários na feature de Agendamentos.